### PR TITLE
Single-property objects kept on one line without trailing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,17 @@ function SomeController(
 
 ## Objects
 
-#### Leave a trailing comma in object literal definitions.
+#### When an object literal has more than one property, split it into one property per line, leaving a trailing comma.
 
-_Why_: easier to reorder existing lines without editing them, and makes new lines clearer in the diff.
+_Why_: keeps lines below 80 characters, after which readability declines. Trailing commas make it easier to reorder existing lines without editing them, and makes new lines clearer in the diff.
 
 ```js
+// good
+{ foo: 2 }
+
+// bad
+{ foo: 2, bar: 3 }
+
 // bad
 {
   foo: 2,


### PR DESCRIPTION
@jackfranklin Hey, we seem to treat objects with one property like this (ie, one line, no trailing comma) but don't explicitly say in the style guide, does it seem like something worth putting in? Could be its own heading actually but makes sense as one big rule as well, I think.